### PR TITLE
Vis miss ly axis flip

### DIFF
--- a/R/vis_miss_ly.R
+++ b/R/vis_miss_ly.R
@@ -40,13 +40,14 @@ vis_miss_ly <- function(x){
                   hoverinfo = "text",
                   type = "heatmap",
                   colors = c("grey80", "grey20"),
-                  colorbar = list(ticktext = c("Present","Missing"),
-                                  tickvals = seq_along(categories))) %>%
+                  colorbar = list(
+                    ticktext = c("Present","Missing"),
+                    tickvals = seq_along(categories)
+                    )) %>%
     plotly::layout(
       xaxis = list(side = "top"),
       yaxis = list(autorange = "reversed")
       )
 
 }
-
 

--- a/R/vis_miss_ly.R
+++ b/R/vis_miss_ly.R
@@ -42,7 +42,12 @@ vis_miss_ly <- function(x){
                   colors = c("grey80", "grey20"),
                   colorbar = list(ticktext = c("Present","Missing"),
                                   tickvals = seq_along(categories))) %>%
-    plotly::layout(xaxis = list(title = ""))
+    plotly::layout(xaxis = list(title = "",
+                                tickmode = "array",
+                                tickvals = list(),
+                                ticktext = "",
+                                mirror = "allticks"),
+                   yaxis = list(autorange = "reversed"))
 
 }
 

--- a/R/vis_miss_ly.R
+++ b/R/vis_miss_ly.R
@@ -42,12 +42,10 @@ vis_miss_ly <- function(x){
                   colors = c("grey80", "grey20"),
                   colorbar = list(ticktext = c("Present","Missing"),
                                   tickvals = seq_along(categories))) %>%
-    plotly::layout(xaxis = list(title = "",
-                                tickmode = "array",
-                                tickvals = list(),
-                                ticktext = "",
-                                mirror = "allticks"),
-                   yaxis = list(autorange = "reversed"))
+    plotly::layout(
+      xaxis = list(side = "top"),
+      yaxis = list(autorange = "reversed")
+      )
 
 }
 


### PR DESCRIPTION
merge in the axis changes for vis_miss_ly - it now has:

* the x axis at the top
* the y axis flipped

This is much closer to `visdat::vis_miss`, but still needs:

* a proper legend
* description of the amount of missings on the columns/legend.

At the moment I am happy to let these slide past