### PR TITLE
Update README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -184,7 +184,7 @@ vis_compare(chickwts, chickwts_diff_2)
 
 `vis_expect` visualises certain conditions or values in your data. For example,
 If you are not sure whether to expect values greater than 25 in your data
-(airquality), you could write: `vis_expect(airquality, ~.x >= 25)`, and you can
+(airquality), you could write: `vis_expect(airquality, ~.x>=25)`, and you can
 see if there are times where the  values in your data are greater than or equal
 to 25:
 


### PR DESCRIPTION
Removing the spaces in " >= " results in proper in-line display of the R code under "Using `vis_expect()`". It appears that markdown parses the character combination " >" as a line break even when surrounded by back ticks. (Could be manually fixed in README.md by removing line break)