### PR TITLE
Remove typo preventing vis_expect to show

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -27,7 +27,7 @@ reference:
   - title: "Visualise whether a value you expect is in a data frame"
     desc: >
       Visualise where certain conditions or values are TRUE in your data.
-    contents::
+    contents:
       - vis_expect
   - title: "Visualise correlations in a dataframe"
     desc: >


### PR DESCRIPTION
Hi @njtierney!
Great package as always! I really like `visdat` and `naniar` for basic data exploration.

I've noticed that `vis_expect()` doesn't show on the pkgdown website and I think it's because of this typo.